### PR TITLE
Explicitly handle semicolon comments in pescan db

### DIFF
--- a/lib/rex/pescan/analyze.rb
+++ b/lib/rex/pescan/analyze.rb
@@ -23,7 +23,7 @@ module Analyze
       fd = File.open(param['database'], 'rb')
       fd.each_line do |line|
         case line
-        when /^\s*#/
+        when /^\s*[#;]/
           next
         when /\[\s*(.*)\s*\]/
           if (name)


### PR DESCRIPTION
The pescan db is INI format which commonly has comments starting with a semicolon.

This PR makes the db parser also treat lines starting with a semicolon as comments