### PR TITLE
Fixes section boundary check for offsets  

### DIFF
--- a/lib/rex/peparsey/section.rb
+++ b/lib/rex/peparsey/section.rb
@@ -112,7 +112,7 @@ class Section
   end
 
   def contains_offset?(offset)
-    offset >= 0 && offset < size
+    offset >= 0 && offset <= size
   end
 
   def contains_file_offset?(foffset)


### PR DESCRIPTION
The `Section#size` returns `_isource.size`, which reflects `SizeOfRawData` — sections such as  .bss always has `SizeOfRawData` = 0. So .bss can never satisfy `contains_rva?`, even for RVAs that legitimately belong to it. This PR addresses that fix.